### PR TITLE
minimal changes to upgrade to Elm 0.18-beta

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,10 +11,10 @@
         "Test.Runner.Html"
     ],
     "dependencies": {
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/example/HtmlRunnerExample.elm
+++ b/example/HtmlRunnerExample.elm
@@ -11,12 +11,11 @@ import String
 import Expect
 import Test exposing (..)
 import Test.Runner.Html
-import Test.Runner.Html.App
 import Fuzz exposing (..)
 import Char
 
 
-main : Program Never (Test.Runner.Html.App.Model Test.Runner.Html.Msg Test.Runner.Html.Model) (Test.Runner.Html.App.Msg Test.Runner.Html.Msg)
+main : Test.Runner.Html.TestProgram
 main =
     [ testWithoutNums
     , testOxfordify

--- a/example/HtmlRunnerExample.elm
+++ b/example/HtmlRunnerExample.elm
@@ -11,11 +11,12 @@ import String
 import Expect
 import Test exposing (..)
 import Test.Runner.Html
+import Test.Runner.Html.App
 import Fuzz exposing (..)
 import Char
 
 
-main : Program Never
+main : Program Never (Test.Runner.Html.App.Model Test.Runner.Html.Msg Test.Runner.Html.Model) (Test.Runner.Html.App.Msg Test.Runner.Html.Msg)
 main =
     [ testWithoutNums
     , testOxfordify

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -9,10 +9,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "mgold/elm-random-pcg": "3.0.0 <= v < 4.0.0"
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Test/Runner/Html.elm
+++ b/src/Test/Runner/Html.elm
@@ -1,11 +1,11 @@
-module Test.Runner.Html exposing (Model, Msg, run, runWithOptions)
+module Test.Runner.Html exposing (TestProgram, run, runWithOptions)
 
 {-| HTML Runner
 
 Runs tests in a browser and reports the results in the DOM. You can bring up
 one of these tests in elm-reactor to have it run and show outputs.
 
-@docs run, runWithOptions, Model, Msg
+@docs run, runWithOptions, TestProgram
 
 -}
 
@@ -17,7 +17,7 @@ import Html.Attributes exposing (..)
 import Dict exposing (Dict)
 import Task
 import Set exposing (Set)
-import Test.Runner.Html.App
+import Test.Runner.Html.App as App
 import String
 import Random.Pcg as Random
 import Time exposing (Time)
@@ -28,7 +28,6 @@ type alias TestId =
     Int
 
 
-{-| -}
 type alias Model =
     { available : Dict TestId (() -> ( List String, List Expectation ))
     , running : Set TestId
@@ -39,10 +38,15 @@ type alias Model =
     }
 
 
-{-| -}
 type Msg
     = Dispatch
     | Finish Time
+
+
+{-| A program which will run tests and report their results.
+-}
+type alias TestProgram =
+    Program Never (App.Model Msg Model) (App.Msg Msg)
 
 
 viewLabels : List String -> List (Html a)
@@ -157,11 +161,6 @@ view model =
 resultsStyle : Html.Attribute a
 resultsStyle =
     style [ ( "font-size", "14px" ), ( "line-height", "1.3" ), ( "font-family", "Menlo, Consolas, \"Fira Mono\", \"DejaVu Sans Mono\", \"Liberation Monospace\", \"Liberation Mono\", Monaco, \"Lucida Console\", \"Courier New\", monospace" ) ]
-
-
-never : Never -> a
-never a =
-    never a
 
 
 viewFailures : ( List String, List Expectation ) -> Html a
@@ -280,7 +279,7 @@ formatDuration time =
 Fuzz tests use a default run count of 100, and an initial seed based on the
 system time when the test runs begin.
 -}
-run : Test -> Program Never (Test.Runner.Html.App.Model Msg Model) (Test.Runner.Html.App.Msg Msg)
+run : Test -> TestProgram
 run =
     runWithOptions Nothing Nothing
 
@@ -288,13 +287,9 @@ run =
 {-| Run the test using the provided options. If `Nothing` is provided for either
 `runs` or `seed`, it will fall back on the options used in [`run`](#run).
 -}
-runWithOptions :
-    Maybe Int
-    -> Maybe Random.Seed
-    -> Test
-    -> Program Never (Test.Runner.Html.App.Model Msg Model) (Test.Runner.Html.App.Msg Msg)
+runWithOptions : Maybe Int -> Maybe Random.Seed -> Test -> TestProgram
 runWithOptions runs seed =
-    Test.Runner.Html.App.run
+    App.run
         { runs = runs
         , seed = seed
         }

--- a/src/Test/Runner/Html.elm
+++ b/src/Test/Runner/Html.elm
@@ -1,11 +1,11 @@
-module Test.Runner.Html exposing (run, runWithOptions)
+module Test.Runner.Html exposing (Model, Msg, run, runWithOptions)
 
 {-| HTML Runner
 
 Runs tests in a browser and reports the results in the DOM. You can bring up
 one of these tests in elm-reactor to have it run and show outputs.
 
-@docs run, runWithOptions
+@docs run, runWithOptions, Model, Msg
 
 -}
 
@@ -21,12 +21,14 @@ import Test.Runner.Html.App
 import String
 import Random.Pcg as Random
 import Time exposing (Time)
+import Tuple
 
 
 type alias TestId =
     Int
 
 
+{-| -}
 type alias Model =
     { available : Dict TestId (() -> ( List String, List Expectation ))
     , running : Set TestId
@@ -37,6 +39,7 @@ type alias Model =
     }
 
 
+{-| -}
 type Msg
     = Dispatch
     | Finish Time
@@ -143,7 +146,7 @@ view model =
 
         failures : List ( List String, List Expectation )
         failures =
-            List.filter (snd >> List.any ((/=) Expect.pass)) model.completed
+            List.filter (Tuple.second >> List.any ((/=) Expect.pass)) model.completed
     in
         div [ style [ ( "width", "960px" ), ( "margin", "auto 40px" ), ( "font-family", "verdana, sans-serif" ) ] ]
             [ summary
@@ -212,7 +215,7 @@ update msg model =
         Dispatch ->
             case model.queue of
                 [] ->
-                    ( model, Task.perform never Finish Time.now )
+                    ( model, Task.perform Finish Time.now )
 
                 testId :: newQueue ->
                     case Dict.get testId model.available of
@@ -245,7 +248,7 @@ update msg model =
 dispatch : Cmd Msg
 dispatch =
     Task.succeed Dispatch
-        |> Task.perform identity identity
+        |> Task.perform identity
 
 
 init : Time -> List (() -> ( List String, List Expectation )) -> ( Model, Cmd Msg )
@@ -258,7 +261,7 @@ init startTime thunks =
         model =
             { available = Dict.fromList indexedThunks
             , running = Set.empty
-            , queue = List.map fst indexedThunks
+            , queue = List.map Tuple.first indexedThunks
             , completed = []
             , startTime = startTime
             , finishTime = Nothing
@@ -277,7 +280,7 @@ formatDuration time =
 Fuzz tests use a default run count of 100, and an initial seed based on the
 system time when the test runs begin.
 -}
-run : Test -> Program Never
+run : Test -> Program Never (Test.Runner.Html.App.Model Msg Model) (Test.Runner.Html.App.Msg Msg)
 run =
     runWithOptions Nothing Nothing
 
@@ -285,7 +288,11 @@ run =
 {-| Run the test using the provided options. If `Nothing` is provided for either
 `runs` or `seed`, it will fall back on the options used in [`run`](#run).
 -}
-runWithOptions : Maybe Int -> Maybe Random.Seed -> Test -> Program Never
+runWithOptions :
+    Maybe Int
+    -> Maybe Random.Seed
+    -> Test
+    -> Program Never (Test.Runner.Html.App.Model Msg Model) (Test.Runner.Html.App.Msg Msg)
 runWithOptions runs seed =
     Test.Runner.Html.App.run
         { runs = runs

--- a/src/Test/Runner/Html/App.elm
+++ b/src/Test/Runner/Html/App.elm
@@ -1,8 +1,8 @@
-module Test.Runner.Html.App exposing (run)
+module Test.Runner.Html.App exposing (Model, Msg, run)
 
 {-| Test runner for a Html.App
 
-@docs run
+@docs run, Model, Msg
 
 -}
 
@@ -10,17 +10,18 @@ import Test exposing (Test)
 import Test.Runner exposing (Runner(..))
 import Expect exposing (Expectation)
 import Html exposing (Html, text)
-import Html.App
 import Task
 import Random.Pcg as Random
 import Time exposing (Time)
 
 
+{-| -}
 type Msg subMsg
     = Init Time
     | SubMsg subMsg
 
 
+{-| -}
 type Model subMsg subModel
     = Uninitialized (SubUpdate subMsg subModel) (Maybe Random.Seed) Int Test (Time -> List (() -> ( List String, List Expectation )) -> ( subModel, Cmd subMsg ))
     | Initialized (SubUpdate subMsg subModel) subModel
@@ -84,7 +85,7 @@ initOrView view model =
             text ""
 
         Initialized _ subModel ->
-            Html.App.map SubMsg (view subModel)
+            Html.map SubMsg (view subModel)
 
 
 type alias SubUpdate msg model =
@@ -135,19 +136,19 @@ toThunksHelp labels runner =
 
 {-| Run the tests and render the results as a Web page.
 -}
-run : RunnerOptions -> AppOptions msg model -> Test -> Program Never
+run : RunnerOptions -> AppOptions msg model -> Test -> Program Never (Model msg model) (Msg msg)
 run runnerOpts appOpts test =
     let
         runs =
             Maybe.withDefault defaultRunCount runnerOpts.runs
 
         cmd =
-            Task.perform fromNever Init Time.now
+            Task.perform Init Time.now
 
         init =
             ( Uninitialized appOpts.update runnerOpts.seed runs test appOpts.init, cmd )
     in
-        Html.App.program
+        Html.program
             { init = init
             , update = initOrUpdate
             , view = initOrView appOpts.view


### PR DESCRIPTION
I made a go at upgrading to 0.18 beta.

I had to expose `Model` and `Msg` from the modules so that I could use them in the type declarations for the functions that return `Program` values. Was that the right way to go?