### PR TITLE
The actual folder name is 'example' and it only has Main.elm in it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Run elm-test suites in the browser
 
 ## Try it
 
-1. `cd examples`
+1. `cd example`
 2. `elm-reactor`
 3. Visit [http://localhost:8000/Main.elm](http://localhost:8000/Main.elm)


### PR DESCRIPTION
Either change folder name or update README.

On a side note: nice demonstration of test failure messaging; like it.